### PR TITLE
Use HTTPS to fetch GPG keys

### DIFF
--- a/tasks/use-apt.yml
+++ b/tasks/use-apt.yml
@@ -11,10 +11,10 @@
   apt: name=python-software-properties state=present update_cache=yes
 
 - name: add APT signing key for td-agent
-  apt_key: url=http://packages.treasuredata.com/GPG-KEY-td-agent state=present
+  apt_key: url=https://packages.treasuredata.com/GPG-KEY-td-agent state=present
 
 - name: add td-agent repository
-  apt_repository: repo='deb http://packages.treasuredata.com/2/{{ ansible_distribution|lower }}/{{ ansible_distribution_release|lower }}/ {{ ansible_distribution_release|lower }} contrib' state=present
+  apt_repository: repo='deb https://packages.treasuredata.com/2/{{ ansible_distribution|lower }}/{{ ansible_distribution_release|lower }}/ {{ ansible_distribution_release|lower }} contrib' state=present
 
 
 - name: install td-agent


### PR DESCRIPTION
The apt task uses HTTP to fetch keys and packages. Change these to HTTPS.

Thanks to @PeterJClaw for noticing this.