### PR TITLE
WIP : Add Stretch Support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
-
+apt_related:
+  - python-software-properties
+  - apt-transport-https
 #
 # variables needed to be defined in user's playbook
 #

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,7 @@ galaxy_info:
           versions:
               - wheezy
               - jessie
+              - stretch
 
         - name: EL
           versions:

--- a/tasks/use-apt.yml
+++ b/tasks/use-apt.yml
@@ -7,11 +7,15 @@
 # @see http://toolbelt.treasuredata.com/sh/install-ubuntu-trusty-td-agent2.sh
 #
 
+- name: set package name on Debian 9
+  set_fact:
+    apt_related:
+      - python3-software-properties
+      - apt-transport-https
+
 - name: install apt-related binaries for Ansible to work
   apt: name={{ item }}  state=present update_cache=yes
-  with_items:
-    - python-software-properties
-    - apt-transport-https
+  with_items: "{{ apt_related }}"
 
 - name: add APT signing key for td-agent
   apt_key: url=https://packages.treasuredata.com/GPG-KEY-td-agent state=present


### PR DESCRIPTION
WIP as tresure data still not provide stretch support :
https://github.com/treasure-data/omnibus-td-agent/issues/107
and the repository is empty for stretch :
https://td-agent-package-browser.herokuapp.com/2/debian/
so this role is failing :
```
TASK [williamyeh.fluentd : add td-agent repository] ***********************************************************************************
fatal: [stretch]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Shared connection to 127.0.0.1 closed.\r\n", "module_stdout": "sudo: unable to resolve host dockerstretch\r\nTraceback (most recent call last):\r\n  File \"/tmp/user/0/ansible_03ULBR/ansible_module_apt_repository.py\", line 565, in <module>\r\n    main()\r\n  File \"/tmp/user/0/ansible_03ULBR/ansible_module_apt_repository.py\", line 553, in main\r\n    cache.update()\r\n  File \"/usr/lib/python2.7/dist-packages/apt/cache.py\", line 464, in update\r\n    raise FetchFailedException(e)\r\napt.cache.FetchFailedException: E:The repository 'https://packages.treasuredata.com/2/debian/stretch stretch Release' does not have a Release file.\r\n", "msg": "MODULE FAILURE", "rc": 0}
```