### PR TITLE
Stricter permissions on log files

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,7 @@
     state: directory
     owner: td-agent
     group: td-agent
+    mode: "0700"
 
 - name: rename default td-agent.conf
   command: creates="/etc/td-agent/td-agent.conf.bak" mv /etc/td-agent/td-agent.conf /etc/td-agent/td-agent.conf.bak
@@ -38,6 +39,7 @@
     dest: /etc/td-agent/td-agent.conf
     owner: td-agent
     group: td-agent
+    mode: "0600"
   when: tdagent_conf_copy is not defined and tdagent_conf_template is not defined
   notify:
     - reload td-agent
@@ -48,6 +50,7 @@
     dest: /etc/td-agent/td-agent.conf
     owner: td-agent
     group: td-agent
+    mode: "0600"
   when: tdagent_conf_copy is defined
   notify:
     - reload td-agent
@@ -58,6 +61,7 @@
     dest: /etc/td-agent/td-agent.conf
     owner: td-agent
     group: td-agent
+    mode: "0600"
   when: tdagent_conf_template is defined
   notify:
     - reload td-agent
@@ -68,6 +72,7 @@
     dest: "/etc/td-agent/conf.d/{{ item.value.dest }}"
     owner: td-agent
     group: td-agent
+    mode: "0600"
   with_dict: '{{ tdagent_conf_others | default({}) }}'
   notify:
     - reload td-agent


### PR DESCRIPTION
## Problem

We have some information in our `td-agent.conf` file that should not be world-readable. The default mode when rendering the config template is 0644, which is world readable.

## Proposed Fix

If this is ok for you, I would just limit the mode to 0600 for files and 0700 for the config folder, respectively. They anyway belong to the td-agent user and need to be accessed only by it.

If you think that there are use cases for different modes, we can also make it configurable.